### PR TITLE
Fix failing tests

### DIFF
--- a/ui/tests/unit/components/NotificationBar.spec.js
+++ b/ui/tests/unit/components/NotificationBar.spec.js
@@ -29,7 +29,7 @@ describe("NotificationBar", () => {
         }
       }
     });
-    expect(wrapper.text()).toBe("Oops!  A mistake was made  Close");
+    expect(wrapper.text()).toBe("Oops! A mistake was made  Close");
   });
 
   test("show error notification with custom header", () => {
@@ -42,7 +42,7 @@ describe("NotificationBar", () => {
         }
       }
     });
-    expect(wrapper.text()).toBe("My Bad!  A mistake was made  Close");
+    expect(wrapper.text()).toBe("My Bad! A mistake was made  Close");
   });
 
   test("show success notification", () => {
@@ -54,7 +54,7 @@ describe("NotificationBar", () => {
         }
       }
     });
-    expect(wrapper.text()).toBe("Success!  Good things happened  Close");
+    expect(wrapper.text()).toBe("Success! Good things happened  Close");
   });
 
   test("show success notification with custom header", () => {
@@ -67,7 +67,7 @@ describe("NotificationBar", () => {
         }
       }
     });
-    expect(wrapper.text()).toBe("Yay!  Good things happened  Close");
+    expect(wrapper.text()).toBe("Yay! Good things happened  Close");
   });
 
   test("show info notification", () => {
@@ -79,7 +79,7 @@ describe("NotificationBar", () => {
         }
       }
     });
-    expect(wrapper.text()).toBe("FYI:  I have something to say  Close");
+    expect(wrapper.text()).toBe("FYI: I have something to say  Close");
   });
 
   test("show info notification with custom header", () => {
@@ -92,7 +92,7 @@ describe("NotificationBar", () => {
         }
       }
     });
-    expect(wrapper.text()).toBe("Attention!  I have something to say  Close");
+    expect(wrapper.text()).toBe("Attention! I have something to say  Close");
   });
 
   test("info notification is default", () => {
@@ -103,7 +103,7 @@ describe("NotificationBar", () => {
         }
       }
     });
-    expect(wrapper.text()).toBe("FYI:  I have something to say  Close");
+    expect(wrapper.text()).toBe("FYI: I have something to say  Close");
   });
 
   test("click to close notification will emit close-notification", () => {


### PR DESCRIPTION
# Before
```

 FAIL  tests/unit/components/NotificationBar.spec.js (5.802s)

  ● NotificationBar › show error notification

    expect(received).toBe(expected) // Object.is equality

    Expected: "Oops!  A mistake was made  Close"
    Received: "Oops! A mistake was made  Close"

      30 |       }
      31 |     });
    > 32 |     expect(wrapper.text()).toBe("Oops!  A mistake was made  Close");
         |                            ^
      33 |   });
      34 |
      35 |   test("show error notification with custom header", () => {

      at Object.<anonymous> (tests/unit/components/NotificationBar.spec.js:32:28)

  ● NotificationBar › show error notification with custom header

    expect(received).toBe(expected) // Object.is equality

    Expected: "My Bad!  A mistake was made  Close"
    Received: "My Bad! A mistake was made  Close"

      43 |       }
      44 |     });
    > 45 |     expect(wrapper.text()).toBe("My Bad!  A mistake was made  Close");
         |                            ^
      46 |   });
      47 |
      48 |   test("show success notification", () => {

      at Object.<anonymous> (tests/unit/components/NotificationBar.spec.js:45:28)

  ● NotificationBar › show success notification

    expect(received).toBe(expected) // Object.is equality

    Expected: "Success!  Good things happened  Close"
    Received: "Success! Good things happened  Close"

      55 |       }
      56 |     });
    > 57 |     expect(wrapper.text()).toBe("Success!  Good things happened  Close");
         |                            ^
      58 |   });
      59 |
      60 |   test("show success notification with custom header", () => {

      at Object.<anonymous> (tests/unit/components/NotificationBar.spec.js:57:28)

  ● NotificationBar › show success notification with custom header

    expect(received).toBe(expected) // Object.is equality

    Expected: "Yay!  Good things happened  Close"
    Received: "Yay! Good things happened  Close"

      68 |       }
      69 |     });
    > 70 |     expect(wrapper.text()).toBe("Yay!  Good things happened  Close");
         |                            ^
      71 |   });
      72 |
      73 |   test("show info notification", () => {

      at Object.<anonymous> (tests/unit/components/NotificationBar.spec.js:70:28)

  ● NotificationBar › show info notification

    expect(received).toBe(expected) // Object.is equality

    Expected: "FYI:  I have something to say  Close"
    Received: "FYI: I have something to say  Close"

      80 |       }
      81 |     });
    > 82 |     expect(wrapper.text()).toBe("FYI:  I have something to say  Close");
         |                            ^
      83 |   });
      84 |
      85 |   test("show info notification with custom header", () => {

      at Object.<anonymous> (tests/unit/components/NotificationBar.spec.js:82:28)

  ● NotificationBar › show info notification with custom header

    expect(received).toBe(expected) // Object.is equality

    Expected: "Attention!  I have something to say  Close"
    Received: "Attention! I have something to say  Close"

      93 |       }
      94 |     });
    > 95 |     expect(wrapper.text()).toBe("Attention!  I have something to say  Close");
         |                            ^
      96 |   });
      97 |
      98 |   test("info notification is default", () => {

      at Object.<anonymous> (tests/unit/components/NotificationBar.spec.js:95:28)

  ● NotificationBar › info notification is default

    expect(received).toBe(expected) // Object.is equality

    Expected: "FYI:  I have something to say  Close"
    Received: "FYI: I have something to say  Close"

      104 |       }
      105 |     });
    > 106 |     expect(wrapper.text()).toBe("FYI:  I have something to say  Close");
          |                            ^
      107 |   });
      108 |
      109 |   test("click to close notification will emit close-notification", () => {

      at Object.<anonymous> (tests/unit/components/NotificationBar.spec.js:106:28)

```

# After
```
 PASS  tests/unit/components/NotificationBar.spec.js
```