### PR TITLE
Add badge for CI to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![License](https://img.shields.io/github/license/Comcast/prombox)](/LICENSE)
 
+[![CI Pipeline Workflow](https://github.com/Comcast/prombox/workflows/CI%20Pipeline/badge.svg?branch=main)](https://github.com/Comcast/prombox/actions?query=workflow%3A%22CI+Pipeline%22+branch%3A%22main%22)
+
 # Prombox
 Sandbox environment for editing and testing prometheus configuration on the fly.
 


### PR DESCRIPTION
- Display bade for the status of the CI Pipeline workflow for the main branch
- Click on badge to view that workflow in the `Actions` tab

Documentation
- https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository